### PR TITLE
add reading on wigosid from netCDF

### DIFF
--- a/src/mdh_modules/nc_to_mmd.py
+++ b/src/mdh_modules/nc_to_mmd.py
@@ -19,6 +19,8 @@ import sys
 import os
 import re
 import validators
+import urllib.request as ul
+import json
 
 class Nc_to_mmd(object):
 
@@ -145,6 +147,10 @@ class Nc_to_mmd(object):
         # Extract activity type. Relying on the ACDD element source or local extension
         if 'source' in global_attributes:
             self.add_activity_type(root, ns_map, ncin, global_attributes)
+
+        # Extract WIGOS links
+        if 'wigosId' in global_attributes:
+            self.add_wigos_related_info(root, ns_map, ncin, global_attributes)
 
         # Extract ISO topic category
 
@@ -570,6 +576,21 @@ class Nc_to_mmd(object):
             myel.text = myactivity
         else:
             myel.text = 'Not available'
+
+    def add_wigos_related_info(self, myxmltree, mynsmap, ncin, myattrs):
+        wigos_id = getattr(ncin, 'wigosId')
+        querywigosid = "https://oscar.wmo.int/surface/rest/api/search/station?wigosId="
+        try:
+            with ul.urlopen(querywigosid+wigos_id, timeout=10) as response:
+                wigos_data = json.load(response)
+                station_name = wigos_data['stationSearchResults'][0]['name']
+                station_url = 'https://oscar.wmo.int/surface/#/search/station/stationReportDetails/'+ wigos_id
+                myel = ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'related_information'))
+                ET.SubElement(myel, ET.QName(mynsmap['mmd'], 'type')).text = 'Observation facility'
+                ET.SubElement(myel, ET.QName(mynsmap['mmd'], 'description')).text = 'WIGOS Station: '+station_name+' ('+wigos_id+')'
+                ET.SubElement(myel, ET.QName(mynsmap['mmd'], 'resource')).text = 'https://oscar.wmo.int/surface/#/search/station/stationReportDetails/'+wigos_id
+        except:
+            print('Could not add wigos information')
 
     # This relies on specific formatting of the global attribute. If not followed, it will be ignored and status set to Scientific. Use local extension to ACDD if available
     def add_operational_status(self, myxmltree, mynsmap, ncin, myattrs):


### PR DESCRIPTION
This will create the linkage to wigos if wigosId is in the global attributes. We can in the future review this by storing info from wigos in a file, so that if the wigos station has already been queried it can just be read from file, instead of making the call to the API again. 