### PR TITLE
add extraction of collection keywords

### DIFF
--- a/src/mdh_modules/nc_to_mmd.py
+++ b/src/mdh_modules/nc_to_mmd.py
@@ -109,8 +109,6 @@ class Nc_to_mmd(object):
         if 'id' in global_attributes:
             self.add_identifier(root, ns_map, ncin, global_attributes)
 
-        # Extract collection?? Not supported by ACDD, add afterwards using filter records from harvester. To be reconsidered in the future.
-
         # Extract title
         if 'title' in global_attributes:
             self.add_title(root, ns_map, ncin)
@@ -132,6 +130,10 @@ class Nc_to_mmd(object):
 
         # Create dataset production status. Default Not available
         self.add_dataset_production_status(root, ns_map)
+
+        # Extract collection (sometimes provided as additional global attribute)
+        if 'collection' in global_attributes:
+            self.add_collection(root, ns_map, ncin)
 
         # Extract last metadata update. Multiple elements to process. Check both date_created and date_metadata_modified
         if 'date_created' in global_attributes:
@@ -250,6 +252,15 @@ class Nc_to_mmd(object):
 
     def add_dataset_production_status(self, myxmltree, mynsmap):
         ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'dataset_production_status')).text = 'Not available'
+
+    def add_collection(self, myxmltree, mynsmap, ncin):
+        valid_identifiers = self.vocabulary.ControlledVocabulary.CollectionKeywords
+        collection = getattr(ncin, 'collection')
+        collection = collection.split(',')
+        for c in collection:
+            c = c.strip()
+            if c in valid_identifiers:
+                ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'collection')).text = c
 
     # Check both date_created and date_metadata_modified
     # FIXME add multiple updates

--- a/src/mdh_modules/traverse_thredds_utils.py
+++ b/src/mdh_modules/traverse_thredds_utils.py
@@ -196,12 +196,18 @@ def traverse_thredds(mystart, dstdir, mydepth):
 
         # Add collection after ds production status
         dsstatus = myxml.find("./mmd:dataset_production_status",namespaces=myroot.nsmap)
-        mynodeadc = ET.Element("{http://www.met.no/schema/mmd}collection")
-        mynodeadc.text = 'ADC'
-        dsstatus.addnext(mynodeadc)
-        mynodensdn = ET.Element("{http://www.met.no/schema/mmd}collection")
-        mynodensdn.text = 'NSDN'
-        mynodeadc.addnext(mynodensdn)
+        tags = []
+        for collection in myxml.findall("./mmd:collection",namespaces=myroot.nsmap):
+            tags.append(collection.text)
+        if 'NSDN' not in tags:
+            mynodensdn = ET.Element("{http://www.met.no/schema/mmd}collection")
+            mynodensdn.text = 'NSDN'
+            dsstatus.addnext(mynodensdn)
+        if 'ADC' not in tags:
+            mynodeadc = ET.Element("{http://www.met.no/schema/mmd}collection")
+            mynodeadc.text = 'ADC'
+            dsstatus.addnext(mynodeadc)
+
 
         # Check and potentially modify activity_type
         mynode = myxml.find("./mmd:activity_type",namespaces=myroot.nsmap)


### PR DESCRIPTION
This PR adds the extraction of a potential "collection" global attribute providing collection keywords. It provides the following:

-  nc_to_mmd.py: adds mmd:collection to the xml file whenever a tag is validating against the controlled list fetched from vocab
-  traverse_thredds_utils.py: is adding ADC and NSDN tags only if not already available. 

The handling of collections could in the future be moved all into nc_to_mmd if that is preferred. 

This closes #40 