### PR TITLE
add file_format and remove http download for ncml files

### DIFF
--- a/src/mdh_modules/nc_to_mmd.py
+++ b/src/mdh_modules/nc_to_mmd.py
@@ -216,6 +216,9 @@ class Nc_to_mmd(object):
         if 'processing_level' in global_attributes or 'operational_status' in global_attributes:
             self.add_operational_status(root, ns_map, ncin, global_attributes)
 
+        # Since in nc_to_mmd we assume files are in netCDF format
+        self.add_storage_information(root, ns_map)
+
         # Check if services should be parsed
         if self.parse_services:
             self.add_web_services(root, ns_map)
@@ -862,6 +865,11 @@ class Nc_to_mmd(object):
                 ET.SubElement(myel,ET.QName(mynsmap['mmd'],'description')).text = refdesc
                 ET.SubElement(myel,ET.QName(mynsmap['mmd'],'resource')).text = refresource
 
+    def add_storage_information(self, myxmltree, mynsmap):
+        myel = ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'storage_information'))
+        myelff = ET.SubElement(myel,ET.QName(mynsmap['mmd'],'file_format'))
+        myelff.text = 'NetCDF-CF'
+
     # Add OPeNDAP URL etc if processing an OPeNDAP URL. 
     def add_web_services(self, myxmltree, mynsmap):
         # Add OPeNDAP data_access if "netcdf_product" is OPeNDAP url
@@ -884,7 +892,10 @@ class Nc_to_mmd(object):
             # Not able to guess URL's for HYRAX. This is not very robust.
             if 'dodsC' in self.netcdf_product:
                 add_wms_data_access = True
-                add_http_data_access = True
+                if not self.netcdf_product.lower().endswith('.ncml'):
+                    add_http_data_access = True
+                else:
+                    add_http_data_access = False
             else:
                 add_wms_data_access = False
                 add_http_data_access = False

--- a/src/mdh_modules/nc_to_mmd.py
+++ b/src/mdh_modules/nc_to_mmd.py
@@ -866,9 +866,13 @@ class Nc_to_mmd(object):
                 ET.SubElement(myel,ET.QName(mynsmap['mmd'],'resource')).text = refresource
 
     def add_storage_information(self, myxmltree, mynsmap):
-        myel = ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'storage_information'))
-        myelff = ET.SubElement(myel,ET.QName(mynsmap['mmd'],'file_format'))
-        myelff.text = 'NetCDF-CF'
+        file_name = self.netcdf_product.split('/')[-1]
+        file_format = file_name.split('.')[-1]
+        valid_extensions = {'nc': 'NetCDF-CF', 'nc4':'NetCDF-CF', 'ncml': 'NcML'}
+        if file_format in valid_extensions.keys():
+            myel = ET.SubElement(myxmltree,ET.QName(mynsmap['mmd'],'storage_information'))
+            myelff = ET.SubElement(myel,ET.QName(mynsmap['mmd'],'file_format'))
+            myelff.text = valid_extensions[file_format]
 
     # Add OPeNDAP URL etc if processing an OPeNDAP URL. 
     def add_web_services(self, myxmltree, mynsmap):

--- a/src/mdh_modules/traverse_thredds_utils.py
+++ b/src/mdh_modules/traverse_thredds_utils.py
@@ -309,7 +309,7 @@ def traverse_thredds(mystart, dstdir, mydepth, mylog, force_mmd=None):
         myroot.insert(-1,related_information)
 
         # Add data_access (not done automatically)
-        if ds.download_url():
+        if ds.download_url() and not infile.lower().endswith('.ncml'):
             data_access = ET.Element(
                     '{http://www.met.no/schema/mmd}data_access')
             data_access_type = ET.SubElement(data_access,


### PR DESCRIPTION
This PR combines two issues: 
- adding the file_format into the storage information (this will help complying to inspire profile)
- removes the HTTP service from data_access when the parsed file is an ncml (since the download will only be a download of the ncml configuration file itself)

Closes #37 and closes #58 