### PR TITLE
add type and orcid/ror in harvestschemaorg

### DIFF
--- a/src/harvestschemaorg.py
+++ b/src/harvestschemaorg.py
@@ -825,6 +825,9 @@ def sosomd2mmd(sosomd):
                                     if 'identifier' in el['affiliation'] and 'ror.org' in el['affiliation']['identifier']:
                                         ror = el['affiliation']['identifier']
                                         myel4.set('uri', ror)
+                        else:
+                            myel4 = ET.SubElement(myel,ET.QName(ns_map['mmd'],'organisation'))
+                            myel4.text = ''
 
                 # sosomd['creator'] type og name
         else:
@@ -866,6 +869,9 @@ def sosomd2mmd(sosomd):
                                 if 'identifier' in sosomd['creator']['affiliation'] and 'ror.org' in sosomd['creator']['affiliation']['identifier']:
                                     ror = sosomd['creator']['affiliation']['identifier']
                                     myel4.set('uri', ror)
+                    else:
+                        myel4 = ET.SubElement(myel,ET.QName(ns_map['mmd'],'organisation'))
+                        myel4.text = ''
 
     #test contributors
     if 'contributor' in mykeys:


### PR DESCRIPTION
This PR is expanding harvestschema.org to parse type and identifiers of personnel.

The type is now added as Person or Organisation and the uri is extracted from the identifier (if orcid or ror).

As example, an old mmd will change from:

```
  <mmd:personnel>
    <mmd:role>Investigator</mmd:role>
    <mmd:name>XXX</mmd:name>
    <mmd:email>xxx@ifg.uni-kiel.de</mmd:email>
  </mmd:personnel>
```
to 
```
  <mmd:personnel>
    <mmd:role>Investigator</mmd:role>
    <mmd:name uri="https://orcid.org/0000-xxxx-yyyy-zzzz-tttt">XXX</mmd:name>
    <mmd:email>xxx@ifg.uni-kiel.de</mmd:email>
    <mmd:type>Person</mmd:type>
    <mmd:organisation uri="https://ror.org/04v76ef78">Institute of Geosciences, Christian-Albrechts University Kiel</mmd:organisation>
  </mmd:personnel>

```
Closes #77 